### PR TITLE
Raise on failed status bulk campaigns

### DIFF
--- a/lib/soapy_bing/ads.rb
+++ b/lib/soapy_bing/ads.rb
@@ -21,11 +21,12 @@ module SoapyBing
       )
     end
 
-    def bulk_campaigns(entities = nil)
+    def bulk_campaigns(entities = nil, polling_settings = {})
       Bulk::Campaigns.new(
         oauth_credentials: oauth_credentials,
         account: account,
-        entities: entities
+        entities: entities,
+        polling_settings: polling_settings
       )
     end
 

--- a/lib/soapy_bing/soap/response/get_bulk_download_status_response.rb
+++ b/lib/soapy_bing/soap/response/get_bulk_download_status_response.rb
@@ -3,7 +3,12 @@ module SoapyBing
   module Soap
     module Response
       class GetBulkDownloadStatusResponse < Base
+        StatusFailed = Class.new(StandardError)
+
         def extract_payload
+          if response['RequestStatus'] == 'Failed'
+            raise StatusFailed, response['Errors'].to_s
+          end
           response.slice('PercentComplete', 'RequestStatus', 'ResultFileUrl')
         end
       end

--- a/lib/soapy_bing/version.rb
+++ b/lib/soapy_bing/version.rb
@@ -1,4 +1,4 @@
 # frozen_string_literal: true
 module SoapyBing
-  VERSION = '0.3.0'
+  VERSION = '0.3.1'
 end

--- a/spec/soapy_bing/soap/response/get_bulk_download_status_response_spec.rb
+++ b/spec/soapy_bing/soap/response/get_bulk_download_status_response_spec.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+RSpec.describe SoapyBing::Soap::Response::GetBulkDownloadStatusResponse do
+  subject(:response) { described_class.new(response_hash) }
+
+  describe '#payload' do
+    context 'in progress status response' do
+      let(:response_hash) do
+        {
+          'Envelope' => {
+            'Body' => {
+              'GetBulkDownloadStatusResponse' => {
+                'Errors' => nil,
+                'PercentComplete' => '42',
+                'RequestStatus' => 'InProgress',
+                'ResultFileUrl' => nil
+              }
+            }
+          }
+        }
+      end
+
+      it 'returns status and percent complete' do
+        expect(response.payload).to include(
+          'PercentComplete' => '42',
+          'RequestStatus' => 'InProgress',
+          'ResultFileUrl' => nil
+        )
+      end
+    end
+
+    context 'failed status response' do
+      let(:response_hash) do
+        {
+          'Envelope' => {
+            'Body' => {
+              'GetBulkDownloadStatusResponse' => {
+                'Errors' => [
+                  'OperationError' => {
+                    'Code' => '0',
+                    'ErrorCode' => 'InternalError',
+                    'Message' => 'An internal error has occurred'
+                  }
+                ],
+                'PercentComplete' => '0',
+                'RequestStatus' => 'Failed',
+                'ResultFileUrl' => nil
+              }
+            }
+          }
+        }
+      end
+
+      it 'raises a StatusFailed exception with error message' do
+        expect { response.payload }.to raise_error(
+          described_class::StatusFailed, /An internal error has occurred/
+        )
+      end
+    end
+  end
+end


### PR DESCRIPTION
I noticed that sometimes Bing Ads API respond very quickly, but sometimes it takes several minutes. So it is useful for client to customize sleeping retryable polling settings. And I set default sleeping time an exponential scheme.

Also sometimes the API return an "internal error" and status as `Failed`. In this case I found better to raise an exception.
